### PR TITLE
Add siembra module and integrate with ambiente schema

### DIFF
--- a/src/generales/ambiente/schema.ts
+++ b/src/generales/ambiente/schema.ts
@@ -11,6 +11,7 @@ import { ICultivo } from "../cultivo/schema";
 import { ISuelo } from "../suelo";
 import { IDepartamento } from "../departamento";
 import { IPrediccionEnfermedades, IPrediccionRiego } from "../prediccion";
+import { ISiembra } from "../siembra";
 
 export interface IAmbiente {
   _id: string;
@@ -25,7 +26,8 @@ export interface IAmbiente {
   idPluviometros?: string[];
   idFreatimetros?: string[];
   idEstacionMeteorologicas?: string[];
-  cultivo?: ICultivo;
+  idSiembras?: string[];
+
   suelos?: ISuelo[];
   capacidadRiego?: number;
   idDepartamento?: string;
@@ -42,6 +44,7 @@ export interface IAmbiente {
   freatimetros?: IFreatimetro[];
   estacionMeteorologicas?: IEstacionMeteorologica[];
   departamento?: IDepartamento;
+  siembras?: ISiembra[];
 }
 
 type OmitirCreate =
@@ -53,7 +56,8 @@ type OmitirCreate =
   | "pluviometros"
   | "freatimetros"
   | "estacionMeteorologicas"
-  | "departamento";
+  | "departamento"
+  | "siembras";
 
 export interface ICreateAmbiente
   extends Omit<Partial<IAmbiente>, OmitirCreate> {}
@@ -67,7 +71,8 @@ type OmitirUpdate =
   | "pluviometros"
   | "freatimetros"
   | "estacionMeteorologicas"
-  | "departamento";
+  | "departamento"
+  | "siembras";
 
 export interface IUpdateAmbiente
   extends Omit<Partial<IAmbiente>, OmitirUpdate> {}

--- a/src/generales/ambiente/schema.ts
+++ b/src/generales/ambiente/schema.ts
@@ -7,7 +7,6 @@ import {
 import { IUbicacion } from "../../auxiliares";
 import { ICliente } from "../cliente";
 import { IEstablecimiento } from "../establecimiento";
-import { ICultivo } from "../cultivo/schema";
 import { ISuelo } from "../suelo";
 import { IDepartamento } from "../departamento";
 import { IPrediccionEnfermedades, IPrediccionRiego } from "../prediccion";
@@ -26,7 +25,7 @@ export interface IAmbiente {
   idPluviometros?: string[];
   idFreatimetros?: string[];
   idEstacionMeteorologicas?: string[];
-  idSiembras?: string[];
+  idSiembra?: string;
 
   suelos?: ISuelo[];
   capacidadRiego?: number;
@@ -44,7 +43,7 @@ export interface IAmbiente {
   freatimetros?: IFreatimetro[];
   estacionMeteorologicas?: IEstacionMeteorologica[];
   departamento?: IDepartamento;
-  siembras?: ISiembra[];
+  siembra?: ISiembra;
 }
 
 type OmitirCreate =
@@ -57,7 +56,7 @@ type OmitirCreate =
   | "freatimetros"
   | "estacionMeteorologicas"
   | "departamento"
-  | "siembras";
+  | "siembra";
 
 export interface ICreateAmbiente
   extends Omit<Partial<IAmbiente>, OmitirCreate> {}
@@ -72,7 +71,7 @@ type OmitirUpdate =
   | "freatimetros"
   | "estacionMeteorologicas"
   | "departamento"
-  | "siembras";
+  | "siembra";
 
 export interface IUpdateAmbiente
   extends Omit<Partial<IAmbiente>, OmitirUpdate> {}

--- a/src/generales/index.ts
+++ b/src/generales/index.ts
@@ -24,5 +24,6 @@ export * from "./auditorias";
 export * from "./semilla";
 export * from "./departamento";
 export * from "./prediccion";
+export * from "./siembra";
 //
 export * from "./config-notificaciones";

--- a/src/generales/siembra/index.ts
+++ b/src/generales/siembra/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/src/generales/siembra/schema.ts
+++ b/src/generales/siembra/schema.ts
@@ -1,0 +1,20 @@
+import { ICultivo } from "../cultivo";
+
+export interface ISiembra {
+  _id: string;
+  fechaCreacion: string;
+  cultivo?: ICultivo;
+  fechaSiembra?: string;
+  fechaCosecha?: string;
+  idSiembraChaman?: string;
+  idAmbiente?: string;
+  active?: boolean;
+}
+
+type OmitirCreate = "_id" | "fechaCreacion";
+
+export interface ICreateSiembra extends Omit<Partial<ISiembra>, OmitirCreate> {}
+
+type OmitirUpdate = "_id" | "fechaCreacion";
+
+export interface IUpdateSiembra extends Omit<Partial<ISiembra>, OmitirUpdate> {}


### PR DESCRIPTION
Introduced the siembra module with its schema and exports. Updated the ambiente schema to support references to siembras, including new fields and type adjustments for create and update interfaces. This enables tracking of siembras within ambientes.