### PR TITLE
Agregando IReporteModoTest dentro del config de dispositivo

### DIFF
--- a/src/aplicaciones/bombeo-v2/dispositivo/schema.ts
+++ b/src/aplicaciones/bombeo-v2/dispositivo/schema.ts
@@ -1,4 +1,5 @@
 import { IReporte } from "../../../generales";
+import { IReporteModoTest } from "../reporteModoTest";
 
 export interface IDispositivoBombeoV2 {
   arranqueAutomatico?: boolean;
@@ -75,4 +76,7 @@ export interface IDispositivoBombeoV2 {
   reporteBombas?: {
     [numero: number]: IReporte;
   };
+
+  // El ultimo reporte de Modo test
+  ultimoTest?: IReporteModoTest;
 }

--- a/src/aplicaciones/bombeo-v2/index.ts
+++ b/src/aplicaciones/bombeo-v2/index.ts
@@ -5,3 +5,4 @@ export * from "./reporteArrancador";
 export * from "./reporteVariador";
 export * from "./reporteCanal";
 export * from "./alertaCentral";
+export * from "./reporteModoTest";

--- a/src/aplicaciones/bombeo-v2/reporteModoTest/index.ts
+++ b/src/aplicaciones/bombeo-v2/reporteModoTest/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/src/aplicaciones/bombeo-v2/reporteModoTest/schema.ts
+++ b/src/aplicaciones/bombeo-v2/reporteModoTest/schema.ts
@@ -1,0 +1,17 @@
+export interface IReporteModoTest {
+  fecha: string;
+  canales: {
+    entrada: "sin_canal" | "ok" | "error_comunicacion" | "error_lectura";
+    salida: "sin_canal" | "ok" | "error_comunicacion" | "error_lectura";
+  };
+  bombas: {
+    [numero: number]: "sin_bomba" | "ok" | "error_comunicacion" | "error_bomba";
+  };
+  resumen: {
+    canalesOk: number;
+    canalesError: number;
+    bombasOk: number;
+    bombasError: number;
+    totalElementos: number;
+  };
+}


### PR DESCRIPTION
IReporteModoTest es contenido por IReporte y vinculado por deveui a la central de bombeo v2 correspondiente.