### PR TITLE
Add 'Sensor de Radar' to TipoDispositivo types

### DIFF
--- a/src/generales/tipoDispositivo/tipoDispositivo.ts
+++ b/src/generales/tipoDispositivo/tipoDispositivo.ts
@@ -22,7 +22,8 @@ export type TipoDispositivo =
   | "Silobolsa"
   | "Tracker"
   | "Sensor de Caudal"
-  | "Sensor RPM";
+  | "Sensor RPM"
+  | "Sensor de Radar";
 
 export const TIPOS_DISPOSITIVOS: TipoDispositivo[] = [
   "Bomba de Cisterna",
@@ -49,4 +50,5 @@ export const TIPOS_DISPOSITIVOS: TipoDispositivo[] = [
   "Tracker",
   "Sensor de Caudal",
   "Sensor RPM",
+  "Sensor de Radar",
 ];


### PR DESCRIPTION
Introduces 'Sensor de Radar' as a new device type in the TipoDispositivo union and updates the TIPOS_DISPOSITIVOS array to include it.